### PR TITLE
Updated Algolia's API client to its latest version

### DIFF
--- a/algoliasearch.js
+++ b/algoliasearch.js
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-var ALGOLIA_VERSION = '2.4.6';
+var ALGOLIA_VERSION = '2.8.1';
 
 /*
  * Copyright (c) 2013 Algolia
@@ -50,43 +50,87 @@ var ALGOLIA_VERSION = '2.4.6';
  * Algolia Search library initialization
  * @param applicationID the application ID you have in your admin interface
  * @param apiKey a valid API key for the service
- * @param method specify if the protocol used is http or https (http by default to make the first search query faster).
- *        You need to use https is you are doing something else than just search queries.
- * @param resolveDNS let you disable first empty query that is launch to warmup the service
- * @param hostsArray (optionnal) the list of hosts that you have received for the service
+ * @param methodOrOptions the hash of parameters for initialization. It can contains:
+ *        - method (optional) specify if the protocol used is http or https (http by default to make the first search query faster).
+ *          You need to use https is you are doing something else than just search queries.
+ *        - hosts (optional) the list of hosts that you have received for the service
+ *        - dsn (optional) set to true if your account has the Distributed Search Option
+ *        - dsnHost (optional) override the automatic computation of dsn hostname
  */
-AlgoliaSearch = function(applicationID, apiKey, method, resolveDNS, hostsArray) {
+var AlgoliaSearch = function(applicationID, apiKey, methodOrOptions, resolveDNS, hosts) {
+    var self = this;
     this.applicationID = applicationID;
     this.apiKey = apiKey;
-
-    if (this._isUndefined(hostsArray)) {
-        hostsArray = [applicationID + '-1.algolia.io',
-                      applicationID + '-2.algolia.io',
-                      applicationID + '-3.algolia.io'];
-    }
+    this.dsn = true;
+    this.dsnHost = null;
     this.hosts = [];
+    this.currentHostIndex = 0;
+    this.requestTimeoutInMs = 2000;
+    this.extraHeaders = [];
+    this.jsonp = null;
+
+    var method;
+    var tld = 'net';
+    if (typeof methodOrOptions === 'string') { // Old initialization
+        method = methodOrOptions;
+    } else {
+        // Take all option from the hash
+        var options = methodOrOptions || {};
+        if (!this._isUndefined(options.method)) {
+            method = options.method;
+        }
+        if (!this._isUndefined(options.tld)) {
+            tld = options.tld;
+        }
+        if (!this._isUndefined(options.dsn)) {
+            this.dsn = options.dsn;
+        }
+        if (!this._isUndefined(options.hosts)) {
+            hosts = options.hosts;
+        }
+        if (!this._isUndefined(options.dsnHost)) {
+            this.dsnHost = options.dsnHost;
+        }
+        if (!this._isUndefined(options.requestTimeoutInMs)) {
+            this.requestTimeoutInMs = +options.requestTimeoutInMs;
+        }
+        if (!this._isUndefined(options.jsonp)) {
+            this.jsonp = options.jsonp;
+        }
+    }
+    // If hosts is undefined, initialize it with applicationID
+    if (this._isUndefined(hosts)) {
+        hosts = [
+            this.applicationID + '-1.algolia.' + tld,
+            this.applicationID + '-2.algolia.' + tld,
+            this.applicationID + '-3.algolia.' + tld
+        ];
+    }
+    // detect is we use http or https
+    this.host_protocol = 'http://';
+    if (this._isUndefined(method) || method === null) {
+        this.host_protocol = ('https:' == document.location.protocol ? 'https' : 'http') + '://';
+    } else if (method === 'https' || method === 'HTTPS') {
+        this.host_protocol = 'https://';
+    }
     // Add hosts in random order
-    for (var i = 0; i < hostsArray.length; ++i) {
+    for (var i = 0; i < hosts.length; ++i) {
         if (Math.random() > 0.5) {
             this.hosts.reverse();
         }
-        if (this._isUndefined(method) || method == null) {
-            this.hosts.push(('https:' == document.location.protocol ? 'https' : 'http') + '://' + hostsArray[i]);
-        } else if (method === 'https' || method === 'HTTPS') {
-            this.hosts.push('https://' + hostsArray[i]);
-        } else {
-            this.hosts.push('http://' + hostsArray[i]);
-        }
+        this.hosts.push(this.host_protocol + hosts[i]);
     }
     if (Math.random() > 0.5) {
         this.hosts.reverse();
     }
-    if (this._isUndefined(resolveDNS) || resolveDNS) {
-        // Perform a call to solve DNS (avoid to slow down the first user query)
-        this._jsonRequest({ method: 'GET',
-                            url: '/1/isalive' });
+    // then add Distributed Search Network host if there is one
+    if (this.dsn || this.dsnHost != null) {
+        if (this.dsnHost) {
+            this.hosts.unshift(this.host_protocol + this.dsnHost);
+        } else {
+            this.hosts.unshift(this.host_protocol + this.applicationID + '-dsn.algolia.' + tld);
+        }
     }
-    this.extraHeaders = [];
 };
 
 function AlgoliaExplainResults(hit, titleAttribute, otherAttributes) {
@@ -231,15 +275,17 @@ AlgoliaSearch.prototype = {
                             callback: callback });
     },
     /*
-     * List all existing indexes
+     * List all existing indexes (paginated)
      *
      * @param callback the result callback with two arguments
      *  success: boolean set to true if the request was successfull
      *  content: the server answer with index list or error description if success is false.
+     * @param page The page to retrieve, starting at 0.
      */
-    listIndexes: function(callback) {
+    listIndexes: function(callback, page) {
+        var params = page ? '?page=' + page : '';
         this._jsonRequest({ method: 'GET',
-                            url: '/1/indexes/',
+                            url: '/1/indexes' + params,
                             callback: callback });
     },
 
@@ -399,7 +445,7 @@ AlgoliaSearch.prototype = {
      */
     addQueryInBatch: function(indexName, query, args) {
         var params = 'query=' + encodeURIComponent(query);
-        if (!this._isUndefined(args) && args != null) {
+        if (!this._isUndefined(args) && args !== null) {
             params = this._getSearchParams(args, params);
         }
         this.batch.push({ indexName: indexName, params: params });
@@ -420,15 +466,17 @@ AlgoliaSearch.prototype = {
     sendQueriesBatch: function(callback, delay) {
         var as = this;
         var params = {requests: [], apiKey: this.apiKey, appID: this.applicationID};
-        if (this.userToken)
+        if (this.userToken) {
             params['X-Algolia-UserToken'] = this.userToken;
-        if (this.tagFilters)
+        }
+        if (this.tagFilters) {
             params['X-Algolia-TagFilters'] = this.tagFilters;
+        }
         for (var i = 0; i < as.batch.length; ++i) {
             params.requests.push(as.batch[i]);
         }
         window.clearTimeout(as.onDelayTrigger);
-        if (!this._isUndefined(delay) && delay != null && delay > 0) {
+        if (!this._isUndefined(delay) && delay !== null && delay > 0) {
             var onDelayTrigger = window.setTimeout( function() {
                 as._sendQueriesBatch(params, callback);
             }, delay);
@@ -437,6 +485,19 @@ AlgoliaSearch.prototype = {
             this._sendQueriesBatch(params, callback);
         }
     },
+
+   /**
+     * Set the number of milliseconds a request can take before automatically being terminated.
+     * 
+     * @param {Number} milliseconds
+     */
+    setRequestTimeout: function(milliseconds)
+    {
+        if (milliseconds) {
+            this.requestTimeoutInMs = parseInt(milliseconds, 10);
+        }
+    },
+
     /*
      * Index class constructor.
      * You should not use this method directly but use initIndex() function
@@ -447,22 +508,58 @@ AlgoliaSearch.prototype = {
         this.typeAheadArgs = null;
         this.typeAheadValueOption = null;
     },
-
+   /**
+     * Add an extra field to the HTTP request
+     * 
+     * @param key the header field name
+     * @param value the header field value
+     */
     setExtraHeader: function(key, value) {
         this.extraHeaders.push({ key: key, value: value});
     },
 
     _sendQueriesBatch: function(params, callback) {
-        this._jsonRequest({ cache: this.cache,
-                               method: 'POST',
-                               url: '/1/indexes/*/queries',
-                               body: params,
-                               callback: callback });
+        if (this.jsonp === null) {
+            var self = this;
+            this._jsonRequest({ cache: this.cache,
+                method: 'POST',
+                url: '/1/indexes/*/queries',
+                body: params,
+                callback: function(success, content) {
+                    if (!success) {
+                        // retry first with JSONP
+                        self.jsonp = true;
+                        self._sendQueriesBatch(params, callback);
+                    } else {
+                        self.jsonp = false;
+                        callback && callback(success, content);
+                    }
+                }
+            });
+        } else if (this.jsonp) {
+            var jsonpParams = '';
+            for (var i = 0; i < params.requests.length; ++i) {
+                var q = '/1/indexes/' + encodeURIComponent(params.requests[i].indexName) + '?' + params.requests[i].params;
+                jsonpParams += i + '=' + encodeURIComponent(q) + '&';
+            }
+            this._jsonRequest({ cache: this.cache,
+                                   method: 'GET',
+                                   url: '/1/indexes/*',
+                                   body: { params: jsonpParams },
+                                   callback: callback });
+        } else {
+            this._jsonRequest({ cache: this.cache,
+                                   method: 'POST',
+                                   url: '/1/indexes/*/queries',
+                                   body: params,
+                                   callback: callback});
+        }
     },
     /*
      * Wrapper that try all hosts to maximize the quality of service
      */
     _jsonRequest: function(opts) {
+        var successiveRetryCount = 0;
         var self = this;
         var callback = opts.callback;
         var cache = null;
@@ -474,97 +571,237 @@ AlgoliaSearch.prototype = {
             cache = opts.cache;
             if (!this._isUndefined(cache[cacheID])) {
                 if (!this._isUndefined(callback)) {
-                    callback(true, cache[cacheID]);
+                    setTimeout(function () { callback(true, cache[cacheID]); }, 1);
                 }
                 return;
             }
         }
 
-        var impl = function(position) {
-            var idx = 0;
-            if (!self._isUndefined(position)) {
-                idx = position;
-            }
-            if (self.hosts.length <= idx) {
+        var impl = function() {
+            if (successiveRetryCount >= self.hosts.length) {
                 if (!self._isUndefined(callback)) {
-                    callback(false, { message: 'Cannot contact server'});
+                    successiveRetryCount = 0;
+                    callback(false, { message: 'Cannot connect the Algolia\'s Search API. Please send an email to support@algolia.com to report the issue.' });
                 }
                 return;
             }
             opts.callback = function(retry, success, res, body) {
                 if (!success && !self._isUndefined(body)) {
-                    console.log('Error: ' + body.message);
+                    window.console && console.log('Error: ' + body.message);
                 }
                 if (success && !self._isUndefined(opts.cache)) {
                     cache[cacheID] = body;
                 }
-                if (!success && retry && (idx + 1) < self.hosts.length) {
-                    impl(idx + 1);
+                if (!success && retry) {
+                    self.currentHostIndex = ++self.currentHostIndex % self.hosts.length;
+                    successiveRetryCount += 1;
+                    impl();
                 } else {
+                    successiveRetryCount = 0;
                     if (!self._isUndefined(callback)) {
                         callback(success, body);
                     }
                 }
             };
-            opts.hostname = self.hosts[idx];
+            opts.hostname = self.hosts[self.currentHostIndex];
             self._jsonRequestByHost(opts);
         };
         impl();
     },
 
     _jsonRequestByHost: function(opts) {
-        var body = null;
         var self = this;
+        var url = opts.hostname + opts.url;
+
+        if (this.jsonp) {
+            this._makeJsonpRequestByHost(url, opts);
+        } else {
+            this._makeXmlHttpRequestByHost(url, opts);
+        }
+    },
+
+    /**
+     * Make a JSONP request
+     *
+     * @param url request url (includes endpoint and path)
+     * @param opts all request options
+     */
+    _makeJsonpRequestByHost: function(url, opts) {
+        if (opts.method !== 'GET') {
+            opts.callback(true, false, null, { 'message': 'Method ' + opts.method + ' ' + url + ' is not supported by JSONP.' });
+            return;
+        }
+
+        this.jsonpCounter = this.jsonpCounter || 0;
+        this.jsonpCounter += 1;
+        var head = document.getElementsByTagName('head')[0];
+        var script = document.createElement('script');
+        var cb = 'algoliaJSONP_' + this.jsonpCounter;
+        var done = false;
+        var ontimeout = null;
+
+        window[cb] = function(data) {
+            opts.callback(false, true, null, data);
+            try { delete window[cb]; } catch (e) { window[cb] = undefined; }
+        };
+
+        script.type = 'text/javascript';
+        script.src = url + '?callback=' + cb + ',' + this.applicationID + ',' + this.apiKey;
+
+        if (opts.body['X-Algolia-TagFilters']) {
+            script.src += '&X-Algolia-TagFilters=' + encodeURIComponent(opts.body['X-Algolia-TagFilters']);
+        }
+
+        if (opts.body['X-Algolia-UserToken']) {
+            script.src += '&X-Algolia-UserToken=' + encodeURIComponent(opts.body['X-Algolia-UserToken']);
+        }
+
+        if (opts.body && opts.body.params) {
+            script.src += '&' + opts.body.params;
+        }
+
+        ontimeout = setTimeout(function() {
+            script.onload = script.onreadystatechange = script.onerror = null;
+            window[cb] = function(data) {
+                try { delete window[cb]; } catch (e) { window[cb] = undefined; }
+            };
+
+            opts.callback(true, false, null, { 'message': 'Timeout - Failed to load JSONP script.' });
+            head.removeChild(script);
+
+            clearTimeout(ontimeout);
+            ontimeout = null;
+
+        }, this.requestTimeoutInMs);
+
+        script.onload = script.onreadystatechange = function() {
+            clearTimeout(ontimeout);
+            ontimeout = null;
+
+            if (!done && (!this.readyState || this.readyState == 'loaded' || this.readyState == 'complete')) {
+                done = true;
+
+                if (typeof window[cb + '_loaded'] === 'undefined') {
+                    opts.callback(true, false, null, { 'message': 'Failed to load JSONP script.' });
+                    try { delete window[cb]; } catch (e) { window[cb] = undefined; }
+                } else {
+                    try { delete window[cb + '_loaded']; } catch (e) { window[cb + '_loaded'] = undefined; }
+                }
+                script.onload = script.onreadystatechange = null; // Handle memory leak in IE
+                head.removeChild(script);
+            }
+        };
+
+        script.onerror = function() {
+            clearTimeout(ontimeout);
+            ontimeout = null;
+
+            opts.callback(true, false, null, { 'message': 'Failed to load JSONP script.' });
+            head.removeChild(script);
+            try { delete window[cb]; } catch (e) { window[cb] = undefined; }
+        };
+
+        head.appendChild(script);
+    },
+
+    /**
+     * Make a XmlHttpRequest
+     * 
+     * @param url request url (includes endpoint and path)
+     * @param opts all request opts
+     */
+    _makeXmlHttpRequestByHost: function(url, opts) {
+        var self = this;
+        var xmlHttp = window.XMLHttpRequest ? new XMLHttpRequest() : {};
+        var body = null;
+        var ontimeout = null;
+
         if (!this._isUndefined(opts.body)) {
             body = JSON.stringify(opts.body);
         }
-        var url = opts.hostname + opts.url;
-        var xmlHttp = null;
-
-        xmlHttp = new XMLHttpRequest();
+        
         if ('withCredentials' in xmlHttp) {
             xmlHttp.open(opts.method, url , true);
-            xmlHttp.setRequestHeader('X-Algolia-API-Key', this.apiKey);
-            xmlHttp.setRequestHeader('X-Algolia-Application-Id', this.applicationID);
+            if (this._isUndefined(opts.removeCustomHTTPHeaders) || !opts.removeCustomHTTPHeaders) {
+                      xmlHttp.setRequestHeader('X-Algolia-API-Key', this.apiKey);
+                      xmlHttp.setRequestHeader('X-Algolia-Application-Id', this.applicationID);
+            }
+            xmlHttp.timeout = this.requestTimeoutInMs;
             for (var i = 0; i < this.extraHeaders.length; ++i) {
                 xmlHttp.setRequestHeader(this.extraHeaders[i].key, this.extraHeaders[i].value);
             }
-            if (body != null) {
+            if (body !== null) {
                 xmlHttp.setRequestHeader('Content-type', 'application/json');
             }
-        } else if (typeof XDomainRequest != 'undefined') {
+        } else if (typeof XDomainRequest !== 'undefined') {
             // Handle IE8/IE9
             // XDomainRequest only exists in IE, and is IE's way of making CORS requests.
             xmlHttp = new XDomainRequest();
             xmlHttp.open(opts.method, url);
         } else {
             // very old browser, not supported
-            console.log('your browser is too old to support CORS requests');
+            opts.callback(false, false, null, { 'message': 'CORS not supported' });
+            return;
         }
-        xmlHttp.send(body);
+
+        ontimeout = setTimeout(function() {
+            xmlHttp.abort();
+            // Prevent Internet Explorer 9, JScript Error c00c023f
+            if (xmlHttp.aborted === true) {
+              stopLoadAnimation();
+              return;
+            }
+            opts.callback(true, false, null, { 'message': 'Timeout - Could not connect to endpoint ' + url } );
+
+            clearTimeout(ontimeout);
+            ontimeout = null;
+
+        }, this.requestTimeoutInMs);
+
         xmlHttp.onload = function(event) {
-            if (!self._isUndefined(event) && event.target != null) {
+            clearTimeout(ontimeout);
+            ontimeout = null;
+
+            if (!self._isUndefined(event) && event.target !== null) {
                 var retry = (event.target.status === 0 || event.target.status === 503);
-                var success = (event.target.status === 200 || event.target.status === 201);
-                opts.callback(retry, success, event.target, event.target.response != null ? JSON.parse(event.target.response) : null);
+                var success = false;
+                var response = null;
+
+                if (typeof XDomainRequest !== 'undefined') {
+                    // Handle CORS requests IE8/IE9
+                    response = event.target.responseText;
+                    success = (response && response.length > 0);
+                }
+                else {
+                    response = event.target.response;
+                    success = (event.target.status === 200 || event.target.status === 201);
+                }
+
+                opts.callback(retry, success, event.target, response ? JSON.parse(response) : null);
             } else {
                 opts.callback(false, true, event, JSON.parse(xmlHttp.responseText));
             }
         };
-        xmlHttp.onerror = function() {
-            opts.callback(true, false, null, { 'message': 'Could not connect to Host'} );
+        xmlHttp.ontimeout = function(event) { // stop the network call but rely on ontimeout to call opt.callback
         };
+        xmlHttp.onerror = function(event) {
+            clearTimeout(ontimeout);
+            ontimeout = null;
+            opts.callback(true, false, null, { 'message': 'Could not connect to host', 'error': event } );
+        };
+
+        xmlHttp.send(body);
     },
 
      /*
      * Transform search param object in query string
      */
     _getSearchParams: function(args, params) {
-        if (this._isUndefined(args) || args == null) {
+        if (this._isUndefined(args) || args === null) {
             return params;
         }
         for (var key in args) {
-            if (key != null && args.hasOwnProperty(key)) {
+            if (key !== null && args.hasOwnProperty(key)) {
                 params += (params.length === 0) ? '?' : '&';
                 params += key + '=' + encodeURIComponent(Object.prototype.toString.call(args[key]) === '[object Array]' ? JSON.stringify(args[key]) : args[key]);
             }
@@ -752,7 +989,7 @@ AlgoliaSearch.prototype.Index.prototype = {
          *  content: the server answer that contains 3 elements: createAt, taskId and objectID
          */
         deleteObject: function(objectID, callback) {
-            if (objectID == null || objectID.length === 0) {
+            if (objectID === null || objectID.length === 0) {
                 callback(false, { message: 'empty objectID'});
                 return;
             }
@@ -832,11 +1069,11 @@ AlgoliaSearch.prototype.Index.prototype = {
         search: function(query, callback, args, delay) {
             var indexObj = this;
             var params = 'query=' + encodeURIComponent(query);
-            if (!this.as._isUndefined(args) && args != null) {
+            if (!this.as._isUndefined(args) && args !== null) {
                 params = this.as._getSearchParams(args, params);
             }
             window.clearTimeout(indexObj.onDelayTrigger);
-            if (!this.as._isUndefined(delay) && delay != null && delay > 0) {
+            if (!this.as._isUndefined(delay) && delay !== null && delay > 0) {
                 var onDelayTrigger = window.setTimeout( function() {
                     indexObj._search(params, callback);
                 }, delay);
@@ -856,7 +1093,7 @@ AlgoliaSearch.prototype.Index.prototype = {
         browse: function(page, callback, hitsPerPage) {
             var indexObj = this;
             var params = '?page=' + page;
-            if (!_.isUndefined(hitsPerPage)) {
+            if (!this.as._isUndefined(hitsPerPage)) {
                 params += '&hitsPerPage=' + hitsPerPage;
             }
             this.as._jsonRequest({ method: 'GET',
@@ -1091,15 +1328,42 @@ AlgoliaSearch.prototype.Index.prototype = {
         ///
         _search: function(params, callback) {
             var pObj = {params: params, apiKey: this.as.apiKey, appID: this.as.applicationID};
-            if (this.as.tagFilters)
+            if (this.as.tagFilters) {
                 pObj['X-Algolia-TagFilters'] = this.as.tagFilters;
-            if (this.as.userToken)
+            }
+            if (this.as.userToken) {
                 pObj['X-Algolia-UserToken'] = this.as.userToken;
-            this.as._jsonRequest({ cache: this.cache,
-                                   method: 'POST',
-                                   url: '/1/indexes/' + encodeURIComponent(this.indexName) + '/query',
-                                   body: pObj,
-                                   callback: callback });
+            }
+            if (this.as.jsonp === null) {
+                var self = this;
+                this.as._jsonRequest({ cache: this.cache,
+                    method: 'POST',
+                    url: '/1/indexes/' + encodeURIComponent(this.indexName) + '/query',
+                    body: pObj,
+                    callback: function(success, content) {
+                        if (!success) {
+                            // retry first with JSONP
+                            self.as.jsonp = true;
+                            self._search(params, callback);
+                        } else {
+                            self.as.jsonp = false;
+                            callback && callback(success, content);
+                        }
+                    }
+                });
+            } else if (this.as.jsonp) {
+                this.as._jsonRequest({ cache: this.cache,
+                                       method: 'GET',
+                                       url: '/1/indexes/' + encodeURIComponent(this.indexName),
+                                       body: pObj,
+                                       callback: callback });
+            } else {
+                this.as._jsonRequest({ cache: this.cache,
+                                       method: 'POST',
+                                       url: '/1/indexes/' + encodeURIComponent(this.indexName) + '/query',
+                                       body: pObj,
+                                       callback: callback});
+            }
         },
 
         // internal attributes
@@ -1135,8 +1399,6 @@ AlgoliaSearch.prototype.Index.prototype = {
  */
 
 (function($) {
-  var self;
-
   var extend = function(out) {
     out = out || {};
     for (var i = 1; i < arguments.length; i++) {
@@ -1167,7 +1429,6 @@ AlgoliaSearch.prototype.Index.prototype = {
     };
 
     this.init(client, index, extend({}, defaults, options));
-    self = this;
   };
 
   AlgoliaSearchHelper.prototype = {
@@ -1185,6 +1446,7 @@ AlgoliaSearch.prototype.Index.prototype = {
       this.page = 0;
       this.refinements = {};
       this.disjunctiveRefinements = {};
+      this.extraQueries = [];
     },
 
     /**
@@ -1202,6 +1464,62 @@ AlgoliaSearch.prototype.Index.prototype = {
       this.refinements = this.refinements || {};
       this.disjunctiveRefinements = this.disjunctiveRefinements || {};
       this._search();
+    },
+    
+    /**
+     * Remove all refinements (disjunctive + conjunctive)
+     */
+    clearRefinements: function() {
+      this.disjunctiveRefinements = {};
+      this.refinements = {};
+    },
+
+    /**
+     * Ensure a facet refinement exists
+     * @param  {string} facet the facet to refine
+     * @param  {string} value the associated value
+     */
+    addDisjunctiveRefine: function(facet, value) {
+      this.disjunctiveRefinements = this.disjunctiveRefinements || {};
+      this.disjunctiveRefinements[facet] = this.disjunctiveRefinements[facet] || {};
+      this.disjunctiveRefinements[facet][value] = true;
+    },
+
+    /**
+     * Ensure a facet refinement does not exist
+     * @param  {string} facet the facet to refine
+     * @param  {string} value the associated value
+     */
+    removeDisjunctiveRefine: function(facet, value) {
+      this.disjunctiveRefinements = this.disjunctiveRefinements || {};
+      this.disjunctiveRefinements[facet] = this.disjunctiveRefinements[facet] || {};
+      try {
+        delete this.disjunctiveRefinements[facet][value];
+      } catch (e) {
+        this.disjunctiveRefinements[facet][value] = undefined; // IE compat
+      }
+    },
+
+    /**
+     * Ensure a facet refinement exists
+     * @param  {string} facet the facet to refine
+     * @param  {string} value the associated value
+     */
+    addRefine: function(facet, value) {
+      var refinement = facet + ':' + value;
+      this.refinements = this.refinements || {};
+      this.refinements[refinement] = true;
+    },
+
+    /**
+     * Ensure a facet refinement does not exist
+     * @param  {string} facet the facet to refine
+     * @param  {string} value the associated value
+     */
+    removeRefine: function(facet, value) {
+      var refinement = facet + ':' + value;
+      this.refinements = this.refinements || {};
+      this.refinements[refinement] = false;
     },
 
     /**
@@ -1265,6 +1583,53 @@ AlgoliaSearch.prototype.Index.prototype = {
       }
     },
 
+    /**
+     * Goto a page
+     * @param  {integer} page The page number
+     */
+    gotoPage: function(page) {
+        this._gotoPage(page);
+    },
+
+    /**
+     * Configure the page but do not trigger a reload
+     * @param  {integer} page The page number
+     */
+    setPage: function(page) {
+      this.page = page;
+    },
+
+    /**
+     * Configure the underlying index name
+     * @param {string} name the index name
+     */
+    setIndex: function(name) {
+      this.index = name;
+    },
+
+    /**
+     * Get the underlying configured index name
+     */
+    getIndex: function() {
+      return this.index;
+    },
+
+    /**
+     * Clear the extra queries added to the underlying batch of queries
+     */
+    clearExtraQueries: function() {
+      this.extraQueries = [];
+    },
+
+    /**
+     * Add an extra query to the underlying batch of queries. Once you add queries
+     * to the batch, the 2nd parameter of the searchCallback will be an object with a `results`
+     * attribute listing all search results.
+     */
+    addExtraQuery: function(index, query, params) {
+      this.extraQueries.push({ index: index, query: query, params: (params || {}) });
+    },
+
     ///////////// PRIVATE
 
     /**
@@ -1285,6 +1650,10 @@ AlgoliaSearch.prototype.Index.prototype = {
       for (var i = 0; i < this.options.disjunctiveFacets.length; ++i) {
         this.client.addQueryInBatch(this.index, this.q, this._getDisjunctiveFacetSearchParams(this.options.disjunctiveFacets[i]));
       }
+      for (var i = 0; i < this.extraQueries.length; ++i) {
+        this.client.addQueryInBatch(this.extraQueries[i].index, this.extraQueries[i].query, this.extraQueries[i].params);
+      }
+      var self = this;
       this.client.sendQueriesBatch(function(success, content) {
         if (!success) {
           self.searchCallback(false, content);
@@ -1292,9 +1661,10 @@ AlgoliaSearch.prototype.Index.prototype = {
         }
         var aggregatedAnswer = content.results[0];
         aggregatedAnswer.disjunctiveFacets = {};
-        for (var i = 1; i < content.results.length; ++i) {
-          for (var facet in content.results[i].facets) {
-            aggregatedAnswer.disjunctiveFacets[facet] = content.results[i].facets[facet];
+        aggregatedAnswer.facetStats = {};
+        for (var i = 0; i < self.options.disjunctiveFacets.length; ++i) {
+          for (var facet in content.results[i + 1].facets) {
+            aggregatedAnswer.disjunctiveFacets[facet] = content.results[i + 1].facets[facet];
             if (self.disjunctiveRefinements[facet]) {
               for (var value in self.disjunctiveRefinements[facet]) {
                 if (!aggregatedAnswer.disjunctiveFacets[facet][value] && self.disjunctiveRefinements[facet][value]) {
@@ -1303,8 +1673,19 @@ AlgoliaSearch.prototype.Index.prototype = {
               }
             }
           }
+          for (var stats in content.results[i + 1].facets_stats) {
+            aggregatedAnswer.facetStats[stats] = content.results[i + 1].facets_stats[stats];
+          }
         }
-        self.searchCallback(true, aggregatedAnswer);
+        if (self.extraQueries.length === 0) {
+          self.searchCallback(true, aggregatedAnswer);
+        } else {
+          var c = { results: [ aggregatedAnswer ] };
+          for (var i = 0; i < self.extraQueries.length; ++i) {
+            c.results.push(content.results[1 + self.options.disjunctiveFacets.length + i]);
+          }
+          self.searchCallback(true, c);
+        }
       });
     },
 
@@ -1313,12 +1694,12 @@ AlgoliaSearch.prototype.Index.prototype = {
      * @return {hash}
      */
     _getHitsSearchParams: function() {
-      return extend({}, this.searchParams, {
+      return extend({}, {
         hitsPerPage: this.options.hitsPerPage,
         page: this.page,
         facets: this.options.facets,
         facetFilters: this._getFacetFilters()
-      });
+      }, this.searchParams);
     },
 
     /**
@@ -1330,6 +1711,9 @@ AlgoliaSearch.prototype.Index.prototype = {
       return extend({}, this.searchParams, {
         hitsPerPage: 1,
         page: 0,
+        attributesToRetrieve: [],
+        attributesToHighlight: [],
+        attributesToSnippet: [],
         facets: facet,
         facetFilters: this._getFacetFilters(facet)
       });
@@ -1364,3 +1748,562 @@ AlgoliaSearch.prototype.Index.prototype = {
     }
   };
 })();
+
+/*
+ * Copyright (c) 2014 Algolia
+ * http://www.algolia.com/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+(function($) {
+  
+  /**
+   * Algolia Places API
+   * @param {string} Your application ID
+   * @param {string} Your API Key
+   */
+  window.AlgoliaPlaces = function(applicationID, apiKey) {
+     this.init(applicationID, apiKey);
+  };
+
+  AlgoliaPlaces.prototype = {
+    /**
+     * @param {string} Your application ID
+     * @param {string} Your API Key
+     */
+    init: function(applicationID, apiKey) {
+      this.client = new AlgoliaSearch(applicationID, apiKey, 'http', true, ['places-1.algolia.io', 'places-2.algolia.io', 'places-3.algolia.io']);
+      this.cache = {};
+    },
+
+    /**
+     * Perform a query
+     * @param  {string} q the user query
+     * @param  {function} searchCallback the result callback called with two arguments:
+     *  success: boolean set to true if the request was successfull
+     *  content: the query answer with an extra 'disjunctiveFacets' attribute
+     * @param {hash} the list of search parameters
+     */
+    search: function(q, searchCallback, searchParams) {
+      var indexObj = this;
+      var params = 'query=' + encodeURIComponent(q);
+      if (!this.client._isUndefined(searchParams) && searchParams != null) {
+          params = this.client._getSearchParams(searchParams, params);
+      }
+      var pObj = {params: params, apiKey: this.client.apiKey, appID: this.client.applicationID};
+      this.client._jsonRequest({ cache: this.cache,
+                                 method: 'POST',
+                                 url: '/1/places/query',
+                                 body: pObj,
+                                 callback: searchCallback,
+                                 removeCustomHTTPHeaders: true });
+    }
+  };
+})();
+
+/*
+    json2.js
+    2014-02-04
+
+    Public Domain.
+
+    NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+    See http://www.JSON.org/js.html
+
+
+    This code should be minified before deployment.
+    See http://javascript.crockford.com/jsmin.html
+
+    USE YOUR OWN COPY. IT IS EXTREMELY UNWISE TO LOAD CODE FROM SERVERS YOU DO
+    NOT CONTROL.
+
+
+    This file creates a global JSON object containing two methods: stringify
+    and parse.
+
+        JSON.stringify(value, replacer, space)
+            value       any JavaScript value, usually an object or array.
+
+            replacer    an optional parameter that determines how object
+                        values are stringified for objects. It can be a
+                        function or an array of strings.
+
+            space       an optional parameter that specifies the indentation
+                        of nested structures. If it is omitted, the text will
+                        be packed without extra whitespace. If it is a number,
+                        it will specify the number of spaces to indent at each
+                        level. If it is a string (such as '\t' or '&nbsp;'),
+                        it contains the characters used to indent at each level.
+
+            This method produces a JSON text from a JavaScript value.
+
+            When an object value is found, if the object contains a toJSON
+            method, its toJSON method will be called and the result will be
+            stringified. A toJSON method does not serialize: it returns the
+            value represented by the name/value pair that should be serialized,
+            or undefined if nothing should be serialized. The toJSON method
+            will be passed the key associated with the value, and this will be
+            bound to the value
+
+            For example, this would serialize Dates as ISO strings.
+
+                Date.prototype.toJSON = function (key) {
+                    function f(n) {
+                        // Format integers to have at least two digits.
+                        return n < 10 ? '0' + n : n;
+                    }
+
+                    return this.getUTCFullYear()   + '-' +
+                         f(this.getUTCMonth() + 1) + '-' +
+                         f(this.getUTCDate())      + 'T' +
+                         f(this.getUTCHours())     + ':' +
+                         f(this.getUTCMinutes())   + ':' +
+                         f(this.getUTCSeconds())   + 'Z';
+                };
+
+            You can provide an optional replacer method. It will be passed the
+            key and value of each member, with this bound to the containing
+            object. The value that is returned from your method will be
+            serialized. If your method returns undefined, then the member will
+            be excluded from the serialization.
+
+            If the replacer parameter is an array of strings, then it will be
+            used to select the members to be serialized. It filters the results
+            such that only members with keys listed in the replacer array are
+            stringified.
+
+            Values that do not have JSON representations, such as undefined or
+            functions, will not be serialized. Such values in objects will be
+            dropped; in arrays they will be replaced with null. You can use
+            a replacer function to replace those with JSON values.
+            JSON.stringify(undefined) returns undefined.
+
+            The optional space parameter produces a stringification of the
+            value that is filled with line breaks and indentation to make it
+            easier to read.
+
+            If the space parameter is a non-empty string, then that string will
+            be used for indentation. If the space parameter is a number, then
+            the indentation will be that many spaces.
+
+            Example:
+
+            text = JSON.stringify(['e', {pluribus: 'unum'}]);
+            // text is '["e",{"pluribus":"unum"}]'
+
+
+            text = JSON.stringify(['e', {pluribus: 'unum'}], null, '\t');
+            // text is '[\n\t"e",\n\t{\n\t\t"pluribus": "unum"\n\t}\n]'
+
+            text = JSON.stringify([new Date()], function (key, value) {
+                return this[key] instanceof Date ?
+                    'Date(' + this[key] + ')' : value;
+            });
+            // text is '["Date(---current time---)"]'
+
+
+        JSON.parse(text, reviver)
+            This method parses a JSON text to produce an object or array.
+            It can throw a SyntaxError exception.
+
+            The optional reviver parameter is a function that can filter and
+            transform the results. It receives each of the keys and values,
+            and its return value is used instead of the original value.
+            If it returns what it received, then the structure is not modified.
+            If it returns undefined then the member is deleted.
+
+            Example:
+
+            // Parse the text. Values that look like ISO date strings will
+            // be converted to Date objects.
+
+            myData = JSON.parse(text, function (key, value) {
+                var a;
+                if (typeof value === 'string') {
+                    a =
+/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)Z$/.exec(value);
+                    if (a) {
+                        return new Date(Date.UTC(+a[1], +a[2] - 1, +a[3], +a[4],
+                            +a[5], +a[6]));
+                    }
+                }
+                return value;
+            });
+
+            myData = JSON.parse('["Date(09/09/2001)"]', function (key, value) {
+                var d;
+                if (typeof value === 'string' &&
+                        value.slice(0, 5) === 'Date(' &&
+                        value.slice(-1) === ')') {
+                    d = new Date(value.slice(5, -1));
+                    if (d) {
+                        return d;
+                    }
+                }
+                return value;
+            });
+
+
+    This is a reference implementation. You are free to copy, modify, or
+    redistribute.
+*/
+
+/*jslint evil: true, regexp: true */
+
+/*members "", "\b", "\t", "\n", "\f", "\r", "\"", JSON, "\\", apply,
+    call, charCodeAt, getUTCDate, getUTCFullYear, getUTCHours,
+    getUTCMinutes, getUTCMonth, getUTCSeconds, hasOwnProperty, join,
+    lastIndex, length, parse, prototype, push, replace, slice, stringify,
+    test, toJSON, toString, valueOf
+*/
+
+
+// Create a JSON object only if one does not already exist. We create the
+// methods in a closure to avoid creating global variables.
+
+if (typeof JSON !== 'object') {
+    JSON = {};
+}
+
+(function () {
+    'use strict';
+
+    function f(n) {
+        // Format integers to have at least two digits.
+        return n < 10 ? '0' + n : n;
+    }
+
+    if (typeof Date.prototype.toJSON !== 'function') {
+
+        Date.prototype.toJSON = function () {
+
+            return isFinite(this.valueOf())
+                ? this.getUTCFullYear()     + '-' +
+                    f(this.getUTCMonth() + 1) + '-' +
+                    f(this.getUTCDate())      + 'T' +
+                    f(this.getUTCHours())     + ':' +
+                    f(this.getUTCMinutes())   + ':' +
+                    f(this.getUTCSeconds())   + 'Z'
+                : null;
+        };
+
+        String.prototype.toJSON      =
+            Number.prototype.toJSON  =
+            Boolean.prototype.toJSON = function () {
+                return this.valueOf();
+            };
+    }
+
+    var cx,
+        escapable,
+        gap,
+        indent,
+        meta,
+        rep;
+
+
+    function quote(string) {
+
+// If the string contains no control characters, no quote characters, and no
+// backslash characters, then we can safely slap some quotes around it.
+// Otherwise we must also replace the offending characters with safe escape
+// sequences.
+
+        escapable.lastIndex = 0;
+        return escapable.test(string) ? '"' + string.replace(escapable, function (a) {
+            var c = meta[a];
+            return typeof c === 'string'
+                ? c
+                : '\\u' + ('0000' + a.charCodeAt(0).toString(16)).slice(-4);
+        }) + '"' : '"' + string + '"';
+    }
+
+
+    function str(key, holder) {
+
+// Produce a string from holder[key].
+
+        var i,          // The loop counter.
+            k,          // The member key.
+            v,          // The member value.
+            length,
+            mind = gap,
+            partial,
+            value = holder[key];
+
+// If the value has a toJSON method, call it to obtain a replacement value.
+
+        if (value && typeof value === 'object' &&
+                typeof value.toJSON === 'function') {
+            value = value.toJSON(key);
+        }
+
+// If we were called with a replacer function, then call the replacer to
+// obtain a replacement value.
+
+        if (typeof rep === 'function') {
+            value = rep.call(holder, key, value);
+        }
+
+// What happens next depends on the value's type.
+
+        switch (typeof value) {
+        case 'string':
+            return quote(value);
+
+        case 'number':
+
+// JSON numbers must be finite. Encode non-finite numbers as null.
+
+            return isFinite(value) ? String(value) : 'null';
+
+        case 'boolean':
+        case 'null':
+
+// If the value is a boolean or null, convert it to a string. Note:
+// typeof null does not produce 'null'. The case is included here in
+// the remote chance that this gets fixed someday.
+
+            return String(value);
+
+// If the type is 'object', we might be dealing with an object or an array or
+// null.
+
+        case 'object':
+
+// Due to a specification blunder in ECMAScript, typeof null is 'object',
+// so watch out for that case.
+
+            if (!value) {
+                return 'null';
+            }
+
+// Make an array to hold the partial results of stringifying this object value.
+
+            gap += indent;
+            partial = [];
+
+// Is the value an array?
+
+            if (Object.prototype.toString.apply(value) === '[object Array]') {
+
+// The value is an array. Stringify every element. Use null as a placeholder
+// for non-JSON values.
+
+                length = value.length;
+                for (i = 0; i < length; i += 1) {
+                    partial[i] = str(i, value) || 'null';
+                }
+
+// Join all of the elements together, separated with commas, and wrap them in
+// brackets.
+
+                v = partial.length === 0
+                    ? '[]'
+                    : gap
+                    ? '[\n' + gap + partial.join(',\n' + gap) + '\n' + mind + ']'
+                    : '[' + partial.join(',') + ']';
+                gap = mind;
+                return v;
+            }
+
+// If the replacer is an array, use it to select the members to be stringified.
+
+            if (rep && typeof rep === 'object') {
+                length = rep.length;
+                for (i = 0; i < length; i += 1) {
+                    if (typeof rep[i] === 'string') {
+                        k = rep[i];
+                        v = str(k, value);
+                        if (v) {
+                            partial.push(quote(k) + (gap ? ': ' : ':') + v);
+                        }
+                    }
+                }
+            } else {
+
+// Otherwise, iterate through all of the keys in the object.
+
+                for (k in value) {
+                    if (Object.prototype.hasOwnProperty.call(value, k)) {
+                        v = str(k, value);
+                        if (v) {
+                            partial.push(quote(k) + (gap ? ': ' : ':') + v);
+                        }
+                    }
+                }
+            }
+
+// Join all of the member texts together, separated with commas,
+// and wrap them in braces.
+
+            v = partial.length === 0
+                ? '{}'
+                : gap
+                ? '{\n' + gap + partial.join(',\n' + gap) + '\n' + mind + '}'
+                : '{' + partial.join(',') + '}';
+            gap = mind;
+            return v;
+        }
+    }
+
+// If the JSON object does not yet have a stringify method, give it one.
+
+    if (typeof JSON.stringify !== 'function') {
+        escapable = /[\\\"\x00-\x1f\x7f-\x9f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g;
+        meta = {    // table of character substitutions
+            '\b': '\\b',
+            '\t': '\\t',
+            '\n': '\\n',
+            '\f': '\\f',
+            '\r': '\\r',
+            '"' : '\\"',
+            '\\': '\\\\'
+        };
+        JSON.stringify = function (value, replacer, space) {
+
+// The stringify method takes a value and an optional replacer, and an optional
+// space parameter, and returns a JSON text. The replacer can be a function
+// that can replace values, or an array of strings that will select the keys.
+// A default replacer method can be provided. Use of the space parameter can
+// produce text that is more easily readable.
+
+            var i;
+            gap = '';
+            indent = '';
+
+// If the space parameter is a number, make an indent string containing that
+// many spaces.
+
+            if (typeof space === 'number') {
+                for (i = 0; i < space; i += 1) {
+                    indent += ' ';
+                }
+
+// If the space parameter is a string, it will be used as the indent string.
+
+            } else if (typeof space === 'string') {
+                indent = space;
+            }
+
+// If there is a replacer, it must be a function or an array.
+// Otherwise, throw an error.
+
+            rep = replacer;
+            if (replacer && typeof replacer !== 'function' &&
+                    (typeof replacer !== 'object' ||
+                    typeof replacer.length !== 'number')) {
+                throw new Error('JSON.stringify');
+            }
+
+// Make a fake root object containing our value under the key of ''.
+// Return the result of stringifying the value.
+
+            return str('', {'': value});
+        };
+    }
+
+
+// If the JSON object does not yet have a parse method, give it one.
+
+    if (typeof JSON.parse !== 'function') {
+        cx = /[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g;
+        JSON.parse = function (text, reviver) {
+
+// The parse method takes a text and an optional reviver function, and returns
+// a JavaScript value if the text is a valid JSON text.
+
+            var j;
+
+            function walk(holder, key) {
+
+// The walk method is used to recursively walk the resulting structure so
+// that modifications can be made.
+
+                var k, v, value = holder[key];
+                if (value && typeof value === 'object') {
+                    for (k in value) {
+                        if (Object.prototype.hasOwnProperty.call(value, k)) {
+                            v = walk(value, k);
+                            if (v !== undefined) {
+                                value[k] = v;
+                            } else {
+                                delete value[k];
+                            }
+                        }
+                    }
+                }
+                return reviver.call(holder, key, value);
+            }
+
+
+// Parsing happens in four stages. In the first stage, we replace certain
+// Unicode characters with escape sequences. JavaScript handles many characters
+// incorrectly, either silently deleting them, or treating them as line endings.
+
+            text = String(text);
+            cx.lastIndex = 0;
+            if (cx.test(text)) {
+                text = text.replace(cx, function (a) {
+                    return '\\u' +
+                        ('0000' + a.charCodeAt(0).toString(16)).slice(-4);
+                });
+            }
+
+// In the second stage, we run the text against regular expressions that look
+// for non-JSON patterns. We are especially concerned with '()' and 'new'
+// because they can cause invocation, and '=' because it can cause mutation.
+// But just to be safe, we want to reject all unexpected forms.
+
+// We split the second stage into 4 regexp operations in order to work around
+// crippling inefficiencies in IE's and Safari's regexp engines. First we
+// replace the JSON backslash pairs with '@' (a non-JSON character). Second, we
+// replace all simple value tokens with ']' characters. Third, we delete all
+// open brackets that follow a colon or comma or that begin the text. Finally,
+// we look to see that the remaining characters are only whitespace or ']' or
+// ',' or ':' or '{' or '}'. If that is so, then the text is safe for eval.
+
+            if (/^[\],:{}\s]*$/
+                    .test(text.replace(/\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g, '@')
+                        .replace(/"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g, ']')
+                        .replace(/(?:^|:|,)(?:\s*\[)+/g, ''))) {
+
+// In the third stage we use the eval function to compile the text into a
+// JavaScript structure. The '{' operator is subject to a syntactic ambiguity
+// in JavaScript: it can begin a block or an object literal. We wrap the text
+// in parens to eliminate the ambiguity.
+
+                j = eval('(' + text + ')');
+
+// In the optional fourth stage, we recursively walk the new structure, passing
+// each name/value pair to a reviver function for possible transformation.
+
+                return typeof reviver === 'function'
+                    ? walk({'': j}, '')
+                    : j;
+            }
+
+// If the text is not JSON parseable, then a SyntaxError is thrown.
+
+            throw new SyntaxError('JSON.parse');
+        };
+    }
+}());


### PR DESCRIPTION
Includes new features, improvements and bug fixes

CHANGELOG

2014-12-09  2.8.1
    \* Enabled DSN by default (is working even if only one datacenter is selected)

2014-11-28  2.8.0
    \* Move to algolia.net by default

2014-11-25  2.7.5
    \* Expose one option to select the TTL (prepare migration to .net, allow to gain some milliseconds compared to .io)

2014-11-12  2.7.4
    \* Expose more options (jsonp & requestTimeoutInMs)
    \* Change the way the JSONP fallback works

2014-10-29  2.7.3
- Reintroduced Algolia Custom Headers (X-Algolia-*) on queries. It was removed to try to remove the CORS OPTIONS query but this has no impact because this is a POST action.

2014-10-27  2.7.2
- Fixed browse method (author @muertet)

2014-10-15  2.7.{0,1}
- Refactor the AlgoliaSearch constructor to allows optional/named arguments

2014-10-07  2.6.6
- Fixed bower integration

2014-09-26  2.6.5
- Optimize disjunctive queries that were retrieving useless attributes

2014-09-23  2.6.4
- Fixed CORS handling issue on IE8/IE9

2014-09-23  2.6.3
- Fixed IE11-based AJAX calls

2014-09-20  2.6.2
- Updated package manager description files: npm and jsdelivr

2014-09-20  2.6.1
- Fixed JSONP call: 'X-Algolia-TagFilters' and 'X-Algolia-UserToken' were not included in the URL.

2014-09-06  2.6.0
- Improved retry strategy with implementation of a timeout on network call.
   Upgrade to this version is highly recommended

2014-09-04  2.5.4
    \* Removed the OPTIONS request for the first isalive query of for all search queries

2014-07-23  2.5.3
    \* AlgoliaSearchHelper: add missing getIndex/setIndex
    \* listIndexes is now paginable

2014-06-05  2.5.2
    \* AlgoliaSearchHelper: add getter/setter methods

2014-05-14  2.5.1
    \* Fixed listIndexes call (trailing slash not compatible with our API anymore)

2014-05-09  2.5.0
    \* If CORS is not available, use JSONP

2014-04-23  2.4.7
     \* Ability to instantiate multiple AlgoliaSearchHelper
